### PR TITLE
calendly integration field

### DIFF
--- a/api/index/indexRouter.js
+++ b/api/index/indexRouter.js
@@ -29,6 +29,9 @@ router.all('/', function (req, res, next) {
  *                api:
  *                  type: boolean
  *                  example: true
+ *                timestamp:
+ *                  type: date
+ *                  example: 1293847921387
  */
 router.get('/', function (req, res) {
   res.status(200).json({ api: 'up', timestamp: Date.now() });

--- a/data/migrations/0002_groomers.js
+++ b/data/migrations/0002_groomers.js
@@ -23,6 +23,7 @@ exports.up = async (knex) => {
     table.float('lat').notNull();
     table.float('lng').notNull();
     table.string('license_number');
+    table.string('personal_calendly_link').notNullable();
   });
 };
 

--- a/data/seeds/003_groomers.js
+++ b/data/seeds/003_groomers.js
@@ -1,4 +1,4 @@
-exports.seed = async function(knex) {
+exports.seed = async function (knex) {
   await knex('groomer').insert([
     {
       user_id: '00ulthapbErVUwVJy4x6',

--- a/data/seeds/003_groomers.js
+++ b/data/seeds/003_groomers.js
@@ -1,4 +1,4 @@
-exports.seed = async function (knex) {
+exports.seed = async function(knex) {
   await knex('groomer').insert([
     {
       user_id: '00ulthapbErVUwVJy4x6',
@@ -16,6 +16,7 @@ exports.seed = async function (knex) {
         'Doggo ipsum pats extremely cuuuuuute porgo. Blop wow such tempt heckin angery woofer shibe dat tungg tho borking doggo noodle horse, heckin good boys snoot corgo floofs. Ur givin me a spook shoob boof very jealous pupper adorable doggo, doggorino doggo. Borkf very good spot shoob you are doing me the shock very good spot blop, big ol vvv pupper borkf. Very jealous pupper I am bekom fat heck floofs blop borkf, wow very biscit mlem pupperino. Long water shoob you are doin me a concern such treat you are doing me the shock ruff borking doggo, I am bekom fat mlem boof pats. Very hand that feed shibe fat boi smol borking doggo with a long snoot for pats, extremely cuuuuuute.',
       lat: 38.678908,
       lng: -81.420319,
+      personal_calendly_link: 'https://calendly.com/muddy_paws',
     },
     {
       user_id: '00ultwew80Onb2vOT4x6',
@@ -33,6 +34,7 @@ exports.seed = async function (knex) {
         'Doggo ipsum shoober borkdrive yapper long water shoob, I am bekom fat. Heckin good boys heckin angery woofer heckin good boys floofs doggo mlem, thicc long doggo ur givin me a spook fluffer doing me a frighten, heck doggorino fat boi pupperino. Adorable doggo corgo doggo much ruin diet, pupper wow such tempt. You are doin me a concern very good spot you are doin me a concern, borkdrive. wow very biscit. Length boy dat tungg tho shoob long bois ur givin me a spook, he made many woofs heckin angery woofer much ruin diet, floofs maximum borkdrive blop. Heckin angery woofer wow such tempt puggorino puggo, long water shoob. Puggo doggo many pats doggo many pats sub woofer, shoob puggo borking doggo floofs. Length boy stop it fren big ol very hand that feed shibe the neighborhood pupper thicc, boof thicc very taste wow extremely cuuuuuute.',
       lat: 32.6718063,
       lng: -96.9329749,
+      personal_calendly_link: 'https://calendly.com/wags_to_riches',
     },
     {
       user_id: '00ultx74kMUmEW8054x6',
@@ -50,6 +52,7 @@ exports.seed = async function (knex) {
         'Doggo ipsum porgo very taste wow boofers snoot, wow very biscit big ol. Sub woofer borkdrive lotsa pats doggorino you are doing me the shock, pupper blep clouds. Much ruin diet very jealous pupper pats borking doggo puggo, such treat long doggo. Very jealous pupper super chub pupperino heckin angery woofer stop it fren pupper, clouds doge pats pupperino.',
       lat: 41.229746668624045,
       lng: -74.18715329129715,
+      personal_calendly_link: 'https://calendly.com/ruff_cuts',
     },
     {
       user_id: '00ultwqjtqt4VCcS24x6',
@@ -67,6 +70,7 @@ exports.seed = async function (knex) {
         'Big ol shibe what a nice floof pupper porgo, extremely cuuuuuute sub woofer puggorino. Extremely cuuuuuute long woofer bork doge shibe, borkdrive heckin good boys you are doin me a concern. Shooberino most angery pupper I have ever seen blep h*ck such treat boof, boofers doge doing me a frighten big ol pupper dat tungg tho, heckin angery woofer most angery pupper I have ever seen doggorino shooberino. Pupper heckin wow such tempt big ol puggorino big ol, most angery pupper I have ever seen I am bekom fat very jealous pupper.',
       lat: 41.929212,
       lng: -74.842247,
+      personal_calendly_link: 'https://calendly.com/diamond_in_the_ruff',
     },
   ]);
 };


### PR DESCRIPTION
## Description ##

personal_calendly_link not nullable field added to groomer table and seeds updated accordingly to be used for scheduling 

## Type ##

- [ ] This is a bugfix.
- [x] This is a new feature.
- [ ] This is part of a feature.

## Organization ##

- [x] Have you linked this pull request to a Trello card?
- [x] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing 

## Review ##

- [ ] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added two reviewers to this pull request?
